### PR TITLE
0.3.1: Adding a fadesOutWhileRemoving option to MKMapView

### DIFF
--- a/ClusterKit.podspec
+++ b/ClusterKit.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "ClusterKit"
-  s.version          = "0.3.0"
+  s.version          = "0.3.1"
   s.summary          = "ClusterKit is a map clustering framework targeting MapKit, Google Maps and Mapbox."
 
   s.description      = <<-DESC

--- a/ClusterKit/Core/CKClusterManager.h
+++ b/ClusterKit/Core/CKClusterManager.h
@@ -187,8 +187,13 @@ FOUNDATION_EXTERN const double kCKMarginFactorWorld;
 @property (nonatomic) CLLocationCoordinate2D to;
 
 /**
- Initializes an animation for the given cluster.
+ Boolean value indicating wheter cluster will disappear once animation is finished
+ */
+@property (nonatomic) BOOL removalAnimation;
 
+/**
+ Initializes an animation for the given cluster.
+ 
  @param cluster The cluster to animate.
  @return The initialized CKClusterAnimation object.
  */
@@ -202,3 +207,4 @@ FOUNDATION_EXTERN const double kCKMarginFactorWorld;
 @end
 
 NS_ASSUME_NONNULL_END
+

--- a/ClusterKit/Core/CKClusterManager.m
+++ b/ClusterKit/Core/CKClusterManager.m
@@ -270,7 +270,7 @@ BOOL CLLocationCoordinateEqual(CLLocationCoordinate2D coordinate1, CLLocationCoo
     
     [self.map addClusters:newClusters];
     
-     NSMutableSet *animations = [NSMutableSet set];
+    NSMutableSet *animations = [NSMutableSet set];
     
     for (CKCluster *newCluster in newClusters) {
         
@@ -288,6 +288,7 @@ BOOL CLLocationCoordinateEqual(CLLocationCoordinate2D coordinate1, CLLocationCoo
                 animation = [[CKClusterAnimation alloc] initWithCluster:neighbor];
                 animation.from = neighbor.coordinate;
                 animation.to = newCluster.coordinate;
+                animation.removalAnimation = YES;
                 [animations addObject:animation];
                 continue;
             }
@@ -326,6 +327,7 @@ BOOL CLLocationCoordinateEqual(CLLocationCoordinate2D coordinate1, CLLocationCoo
         _cluster = cluster;
         _from = kCLLocationCoordinate2DInvalid;
         _to = kCLLocationCoordinate2DInvalid;
+        _removalAnimation = NO;
     }
     return self;
 }
@@ -349,3 +351,4 @@ BOOL CLLocationCoordinateEqual(CLLocationCoordinate2D coordinate1, CLLocationCoo
 }
 
 @end
+

--- a/ClusterKit/MapKit/MKMapView+ClusterKit.h
+++ b/ClusterKit/MapKit/MKMapView+ClusterKit.h
@@ -31,6 +31,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MKMapView (ClusterKit) <CKMap>
 
 /**
+ Fades out while removing animation. Defaults to NO
+ */
+@property (nonatomic) BOOL fadesOutWhileRemoving;
+
+/**
  Shows the specified cluster centered on screen at the greatest possible zoom level.
  
  @param cluster  The cluster to show.
@@ -50,3 +55,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+


### PR DESCRIPTION
Adding option on MKMapView to enable annotationViews being faded out while being animated before removal. 
This allows a smoother animation instead of pins just disappearing.
This is particularly useful in case of single-annotation cluster view being different than a multi-annotation cluster view, in which case it used to go behind, then suddenly disappeared.

Usage:

`mapView.fadesOutWhileRemoving = true`