### PR TITLE
Fix Examle-objc/CKAppDelegate to avoid build error

### DIFF
--- a/Examples/Example-objc/CKAppDelegate.m
+++ b/Examples/Example-objc/CKAppDelegate.m
@@ -34,7 +34,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     
     [GMSServices provideAPIKey:@"<#Enter your google API key#>"];
-    [MGLAccountManager setAccessToken:"<#Enter your Mapbox access token#>"];
+    [MGLAccountManager setAccessToken:@"<#Enter your Mapbox access token#>"];
     
     return YES;
 }


### PR DESCRIPTION
Current example projects results in build error.
This PR fix this problem.