### PR TITLE
Possible fix of the issue #43

### DIFF
--- a/ClusterKit/Core/CKClusterManager.m
+++ b/ClusterKit/Core/CKClusterManager.m
@@ -307,9 +307,8 @@ BOOL CLLocationCoordinateEqual(CLLocationCoordinate2D coordinate1, CLLocationCoo
         }
     }
     
-    [self.map performAnimations:animations.allObjects completion:^(BOOL finished) {
-        [self.map removeClusters:oldClusters];
-    }];
+    [self.map performAnimations:animations.allObjects completion:nil];
+    [self.map removeClusters:oldClusters];
 }
 
 #pragma mark <KPAnnotationTreeDelegate>


### PR DESCRIPTION
https://github.com/hulab/ClusterKit/issues/43

Remove old clusters from the map before the animation of collapsing clusters is completed.

In my project, I was also experiencing a duplication of annotations in clusters, as I was picking up the new clusters in the method `-mapView:regionDidChangeAnimated:` like this:
```
    func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
        mapView.clusterManager.updateClustersIfNeeded()

        // determine if the clusters visible on the map have changed since the last time we checked
        let clusters = mapView.annotations(in: mapView.visibleMapRect).compactMap { $0 as? CKCluster }
        // do something with the clusters ...
```

It seems there was a subtle difference in 2 counterpart methods of `CKClusterManager`:
```
- (void)expand:(NSArray<CKCluster *> *)newClusters from:(NSArray<CKCluster *> *)oldClusters in:(MKMapRect)rect
// and
- (void)collapse:(NSArray<CKCluster *> *)oldClusters to:(NSArray<CKCluster *> *)newClusters in:(MKMapRect)rect
```
as one method was removing `oldClusters` BEFORE the animations were finished and the other method was removing those AFTER the animations were finished.