### PR TITLE
Add read-only property returning array of the clusters within the visible map area.

### DIFF
--- a/ClusterKit/Core/CKClusterManager.h
+++ b/ClusterKit/Core/CKClusterManager.h
@@ -98,6 +98,11 @@ FOUNDATION_EXTERN const double kCKMarginFactorWorld;
 @property (nonatomic, readonly, copy) NSArray<CKCluster *> *clusters;
 
 /**
+ The array of clusters that are currently visible on the map.
+ */
+@property (nonatomic, readonly, copy) NSArray<CKCluster *> *visibleClusters;
+
+/**
  The maximum zoom level for clustering, 20 by default.
  */
 @property (nonatomic) CGFloat maxZoomLevel;

--- a/ClusterKit/Core/CKClusterManager.m
+++ b/ClusterKit/Core/CKClusterManager.m
@@ -97,6 +97,23 @@ BOOL CLLocationCoordinateEqual(CLLocationCoordinate2D coordinate1, CLLocationCoo
     return _clusters.allObjects;
 }
 
+- (NSArray<CKCluster *> *)visibleClusters {
+    NSMutableArray<CKCluster *> *result = [NSMutableArray<CKCluster *> new];
+
+    if (!self.map) return [result copy];
+
+    MKMapRect visibleMapRect = self.map.visibleMapRect;
+
+    NSArray<id<MKAnnotation>> *visibleAnnotations = [self.tree annotationsInRect:visibleMapRect];
+    NSSet<id<MKAnnotation>> *visibleAnnotationsSet = [NSSet setWithArray:visibleAnnotations];
+    for (CKCluster *cluster in _clusters) {
+        if ([visibleAnnotationsSet containsObject:cluster.firstAnnotation]) {
+            [result addObject:cluster];
+        }
+    }
+    return [result copy];
+}
+
 #pragma mark Manage Annotations
 
 - (void)setAnnotations:(NSArray<id<MKAnnotation>> *)annotations {


### PR DESCRIPTION
This is convenient for operating only on the subset of clusters that are currently visible on the map view. For example, if every cluster consists of the list of photos/videos the user have taken, this is convenient to construct a table or a collection view with the photos/videos, that will include only those visible on the map.