### PR TITLE
Mapbox Version 5

### DIFF
--- a/ClusterKit.podspec
+++ b/ClusterKit.podspec
@@ -56,7 +56,7 @@ Pod::Spec.new do |s|
   s.subspec 'Mapbox' do |ss|
     ss.platform = :ios, '9.0'
     ss.dependency 'ClusterKit/Core'
-    ss.dependency 'Mapbox-iOS-SDK', '~> 4.6'
+    ss.dependency 'Mapbox-iOS-SDK', '~> 5.0'
     ss.source_files = 'ClusterKit/Mapbox'
   end
 


### PR DESCRIPTION
Mapbox has moved to 5.x version numbers - this PR updates the podspec to use newer mapbox versions (a quick test has not revealed any issues with clusterkit and 5.x mapbox)