### PR TITLE
Fix 'include of non-modular header inside framework module' error

### DIFF
--- a/ClusterKit/MapKit/MKMapView+ClusterKit.h
+++ b/ClusterKit/MapKit/MKMapView+ClusterKit.h
@@ -21,7 +21,8 @@
 // THE SOFTWARE.
 
 #import <MapKit/MapKit.h>
-#import <ClusterKit/ClusterKit.h>
+#import <ClusterKit/CKMap.h>
+#import <ClusterKit/CKCluster.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ClusterKit/Mapbox/MGLMapView+ClusterKit.h
+++ b/ClusterKit/Mapbox/MGLMapView+ClusterKit.h
@@ -21,7 +21,8 @@
 // THE SOFTWARE.
 
 #import <Mapbox/Mapbox.h>
-#import <ClusterKit/ClusterKit.h>
+#import <ClusterKit/CKMap.h>
+#import <ClusterKit/CKCluster.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ClusterKit/YandexMapKit/YMKMapView+ClusterKit.h
+++ b/ClusterKit/YandexMapKit/YMKMapView+ClusterKit.h
@@ -1,5 +1,6 @@
 #import <YandexMapKit/YMKMapKit.h>
-#import <ClusterKit/ClusterKit.h>
+#import <ClusterKit/CKMap.h>
+#import <ClusterKit/CKCluster.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
I have the following error messages while using ClusterKit through CocoaPods:

> Could not build Objective-C module ‘ClusterKit’
> 
> include of non-modular header inside framework module 'ClusterKit.MKMapView_ClusterKit'

To fix this I replaced imports of <ClusterKit/ClusterKit.h> with imports of only required files.